### PR TITLE
feat: Doughnut 색 옵션 추가

### DIFF
--- a/client/components/Doughnut/index.tsx
+++ b/client/components/Doughnut/index.tsx
@@ -7,18 +7,19 @@ interface DoughnutProps {
   title: string;
   label: string[];
   color: string[];
+  textColor: string;
   size?: number;
 }
 
-function Doughnut({ val, label, title, size = 100, color }: DoughnutProps) {
+function Doughnut({ val, label, title, size = 100, color, textColor }: DoughnutProps) {
   const viewBoxSize = 100;
   const radius = 44;
   const holeRadius = 30;
   const paths = generatePath(val, radius, holeRadius, viewBoxSize);
   const [hover, setHover] = useState<number | null>(null);
   return (
-    <div css={style(size)}>
-      <a>{hover === null ? title : label[hover]}</a>
+    <div css={style.container}>
+      <div css={style.text(size, textColor)}>{hover === null ? title : label[hover]}</div>
       <svg
         width={size}
         height={size}

--- a/client/components/Doughnut/style.ts
+++ b/client/components/Doughnut/style.ts
@@ -1,23 +1,26 @@
 import { css } from '@emotion/react';
 
-export const style = (size: number) => css`
-  position: relative;
-  a {
-    font-size: 13px;
+export const style = {
+  container: css`
+    position: relative;
+    path {
+      transform-origin: 50% 50%;
+      opacity: 0.85;
+      scale: 1;
+      transition: 0.2s;
+    }
+    path:hover {
+      opacity: 1;
+      scale: 1.05;
+      transition: 0.2s;
+    }
+  `,
+  text: (size: number, textColor: string) => css`
     position: absolute;
+    font-size: 13px;
     top: ${size / 2}px;
     left: ${size / 2}px;
     transform: translate(-50%, -50%);
-  }
-  path {
-    transform-origin: 50% 50%;
-    opacity: 0.85;
-    scale: 1;
-    transition: 0.2s;
-  }
-  path:hover {
-    opacity: 1;
-    scale: 1.05;
-    transition: 0.2s;
-  }
-`;
+    color: ${textColor};
+  `,
+};


### PR DESCRIPTION
## 개요
- #58 

## 작업사항
- Doughnut 수정
  - textColor 추가
  - a 태그 div로 대체
```ts
<Doughnut
  label={['마법', '물리', '고정']}
  val={[3123, 1231, 100]}
  textColor={'black'}
  color={['skyblue', 'orange', 'grey']}
  title="딜 유형"
  size={100}
/>
```
