### PR TITLE
fix: SummonerStatCard의 PercentageStat 패딩 추가

### DIFF
--- a/client/components/SummonerStatCard/index.tsx
+++ b/client/components/SummonerStatCard/index.tsx
@@ -176,6 +176,7 @@ function GameContribution({
             deathPercent={death}
             deathAmount={deathAmount}
             color={{ foreground: theme.background, background: theme.foreground }}
+            padding={6}
           />
         </div>
       </div>


### PR DESCRIPTION
## 개요
- #100

## 작업사항
- SummonerStatCard의 PercentageStatistics 패딩값 추가 (`6`)