### PR TITLE
fix: SummonerProfileCard 높이 2px 증가

### DIFF
--- a/client/components/SummonerProfileCard/style.ts
+++ b/client/components/SummonerProfileCard/style.ts
@@ -3,7 +3,7 @@ import { css } from '@emotion/react';
 export const style = {
   container: css`
     width: 235px;
-    height: 187px;
+    height: 189px;
     border-radius: 10px;
     padding: 15px;
     display: flex;


### PR DESCRIPTION
## 개요
- #85

## 작업사항
- SummonerProfileCard와 SummonerStatCard의 높이가 맞지 않던 문제 수정
  - SummonerProfileCard 높이 2px 증가