### PR TITLE
소환사 API 수정 및 리팩토링

### DIFF
--- a/server/src/riot.api/definition/riot.api.exception.ts
+++ b/server/src/riot.api/definition/riot.api.exception.ts
@@ -1,0 +1,12 @@
+import { ServiceUnavailableException } from '@nestjs/common';
+
+export class RiotApiException extends ServiceUnavailableException {
+  riotApiHttpCode: number;
+  riotApiMessage: string;
+
+  constructor(code: number, message: string) {
+    super();
+    this.riotApiHttpCode = code;
+    this.riotApiMessage = message;
+  }
+}

--- a/server/src/riot.api/riot.api.service.ts
+++ b/server/src/riot.api/riot.api.service.ts
@@ -14,7 +14,7 @@ export class RiotApiService {
     this.apiKey = this.configService.get<string>('API_KEY');
   }
 
-  async getSummoner(name: string) {
+  async getSummonerByName(name: string) {
     const { data } = await this.httpService.axiosRef.get<RoitSummonerResponse>(
       `https://kr.api.riotgames.com/lol/summoner/v4/summoners/by-name/${name}`,
       {
@@ -27,6 +27,18 @@ export class RiotApiService {
     return data;
   }
 
+  async getSummonerByPuuid(name: string) {
+    const { data } = await this.httpService.axiosRef.get<RoitSummonerResponse>(
+      `https://kr.api.riotgames.com/lol/summoner/v4/summoners/by-puuid/${name}`,
+      {
+        headers: {
+          'X-Riot-Token': this.apiKey,
+        },
+      },
+    );
+
+    return data;
+  }
   async getChallenges(puuid: string) {
     const { data } = await this.httpService.axiosRef.get<RiotChallengeResponse>(
       `https://kr.api.riotgames.com/lol/challenges/v1/player-data/${puuid}`,

--- a/server/src/riot.api/riot.api.service.ts
+++ b/server/src/riot.api/riot.api.service.ts
@@ -14,39 +14,32 @@ export class RiotApiService {
     this.apiKey = this.configService.get<string>('API_KEY');
   }
 
-  async getSummonerByName(name: string) {
-    const { data } = await this.httpService.axiosRef.get<RoitSummonerResponse>(
-      `https://kr.api.riotgames.com/lol/summoner/v4/summoners/by-name/${name}`,
-      {
-        headers: {
-          'X-Riot-Token': this.apiKey,
-        },
+  call<T>(uri: string) {
+    return this.httpService.axiosRef.get<T>(uri, {
+      headers: {
+        'X-Riot-Token': this.apiKey,
       },
+    });
+  }
+
+  async getSummonerByName(name: string) {
+    const { data } = await this.call<RoitSummonerResponse>(
+      `https://kr.api.riotgames.com/lol/summoner/v4/summoners/by-name/${name}`,
     );
 
     return data;
   }
 
   async getSummonerByPuuid(name: string) {
-    const { data } = await this.httpService.axiosRef.get<RoitSummonerResponse>(
+    const { data } = await this.call<RoitSummonerResponse>(
       `https://kr.api.riotgames.com/lol/summoner/v4/summoners/by-puuid/${name}`,
-      {
-        headers: {
-          'X-Riot-Token': this.apiKey,
-        },
-      },
     );
 
     return data;
   }
   async getChallenges(puuid: string) {
-    const { data } = await this.httpService.axiosRef.get<RiotChallengeResponse>(
+    const { data } = await this.call<RiotChallengeResponse>(
       `https://kr.api.riotgames.com/lol/challenges/v1/player-data/${puuid}`,
-      {
-        headers: {
-          'X-Riot-Token': this.apiKey,
-        },
-      },
     );
 
     return data;

--- a/server/src/riot.api/riot.api.service.ts
+++ b/server/src/riot.api/riot.api.service.ts
@@ -1,6 +1,8 @@
 import { HttpService } from '@nestjs/axios';
-import { Injectable } from '@nestjs/common';
+import { HttpStatus, Injectable } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
+import { AxiosError, HttpStatusCode } from 'axios';
+import { RiotApiException } from './definition/riot.api.exception';
 import { RiotChallengeResponse, RoitSummonerResponse } from './interface';
 
 @Injectable()
@@ -14,34 +16,56 @@ export class RiotApiService {
     this.apiKey = this.configService.get<string>('API_KEY');
   }
 
-  call<T>(uri: string) {
-    return this.httpService.axiosRef.get<T>(uri, {
-      headers: {
-        'X-Riot-Token': this.apiKey,
-      },
-    });
+  async call<T>(uri: string) {
+    try {
+      return await this.httpService.axiosRef.get<T>(uri, {
+        headers: {
+          'X-Riot-Token': this.apiKey,
+        },
+      });
+    } catch (error) {
+      if (error instanceof AxiosError) {
+        const serviceUnavailableCodes = [
+          HttpStatus.BAD_REQUEST,
+          HttpStatus.UNAUTHORIZED,
+          HttpStatus.FORBIDDEN,
+          HttpStatus.METHOD_NOT_ALLOWED,
+          HttpStatus.UNSUPPORTED_MEDIA_TYPE,
+          HttpStatus.TOO_MANY_REQUESTS,
+          HttpStatus.INTERNAL_SERVER_ERROR,
+          HttpStatus.SERVICE_UNAVAILABLE,
+          HttpStatus.GATEWAY_TIMEOUT,
+        ];
+
+        if (serviceUnavailableCodes.includes(+error.code)) {
+          throw new RiotApiException(+error.code, error.message);
+        }
+
+        return null;
+      }
+    }
   }
 
   async getSummonerByName(name: string) {
-    const { data } = await this.call<RoitSummonerResponse>(
-      `https://kr.api.riotgames.com/lol/summoner/v4/summoners/by-name/${name}`,
-    );
-
-    return data;
+    return (
+      await this.call<RoitSummonerResponse>(
+        `https://kr.api.riotgames.com/lol/summoner/v4/summoners/by-name/${name}`,
+      )
+    )?.data;
   }
 
   async getSummonerByPuuid(name: string) {
-    const { data } = await this.call<RoitSummonerResponse>(
-      `https://kr.api.riotgames.com/lol/summoner/v4/summoners/by-puuid/${name}`,
-    );
-
-    return data;
+    return (
+      await this.call<RoitSummonerResponse>(
+        `https://kr.api.riotgames.com/lol/summoner/v4/summoners/by-puuid/${name}`,
+      )
+    )?.data;
   }
   async getChallenges(puuid: string) {
-    const { data } = await this.call<RiotChallengeResponse>(
-      `https://kr.api.riotgames.com/lol/challenges/v1/player-data/${puuid}`,
-    );
-
-    return data;
+    return (
+      await this.call<RiotChallengeResponse>(
+        `https://kr.api.riotgames.com/lol/challenges/v1/player-data/${puuid}`,
+      )
+    )?.data;
   }
 }

--- a/server/src/summoners/summoners.service.ts
+++ b/server/src/summoners/summoners.service.ts
@@ -22,9 +22,9 @@ export class SummonersService {
   async update(summonerName: string) {
     const summonerFromRiot = await this.riotApiService.getSummoner(summonerName);
     const challenges = await this.riotApiService.getChallenges(summonerFromRiot.puuid);
-    const userChallenges = challenges.preferences.challengeIds.map((challengeId) =>
-      challenges.challenges.find((c) => c.challengeId === challengeId),
-    );
+    const userChallenges = challenges.preferences.challengeIds
+      .map((challengeId) => challenges.challenges.find((c) => c.challengeId === challengeId))
+      .filter((c) => !!c);
 
     await this.summonerModel.updateOne(
       { puuid: summonerFromRiot.puuid },

--- a/server/src/summoners/summoners.service.ts
+++ b/server/src/summoners/summoners.service.ts
@@ -24,6 +24,9 @@ export class SummonersService {
     const summonerFromRiot = await (!!summonerFromDb
       ? this.riotApiService.getSummonerByPuuid(summonerFromDb.puuid)
       : this.riotApiService.getSummonerByName(summonerName));
+
+    if (!summonerFromRiot) throw new NotFoundException('소환사를 찾을 수 없습니다.');
+
     const challenges = await this.riotApiService.getChallenges(summonerFromRiot.puuid);
     const userChallenges = challenges.preferences.challengeIds
       .map((challengeId) => challenges.challenges.find((c) => c.challengeId === challengeId))

--- a/server/src/summoners/summoners.service.ts
+++ b/server/src/summoners/summoners.service.ts
@@ -20,7 +20,10 @@ export class SummonersService {
   }
 
   async update(summonerName: string) {
-    const summonerFromRiot = await this.riotApiService.getSummoner(summonerName);
+    const summonerFromDb = await this.summonerModel.findOne({ name: summonerName }).lean();
+    const summonerFromRiot = await (!!summonerFromDb
+      ? this.riotApiService.getSummonerByPuuid(summonerFromDb.puuid)
+      : this.riotApiService.getSummonerByName(summonerName));
     const challenges = await this.riotApiService.getChallenges(summonerFromRiot.puuid);
     const userChallenges = challenges.preferences.challengeIds
       .map((challengeId) => challenges.challenges.find((c) => c.challengeId === challengeId))


### PR DESCRIPTION
## 개요
- #151

## 작업사항
- challenge에 null이 들어가지 않도록 수정
- DB에 이미 존재하는 소환사의 경우 puuid를 이용해 RiotAPI 호출, 존재하지 않는 소환사의 경우 summonerName을 이용해 RiotAPI를 호출하도록 수정
- RiotApiService 공통 부분 추상화
- RiotApiService에서  404를 제외한 나머지 오류는 503 에러를 던지도록 수정
  - 404일 경우 null을 반환