### PR TITLE
/matches/by-puuid/:puuid 구현

### DIFF
--- a/client/components/GameSlot/index.tsx
+++ b/client/components/GameSlot/index.tsx
@@ -21,8 +21,7 @@ interface GameSlotProps {
 
 interface GameSlotSummaryProps {
   me: Participant;
-  participants: Participant[];
-  contribution: TeamContribution;
+  teamContribution: TeamContribution;
 }
 
 interface GameSlotRowProps {
@@ -128,7 +127,7 @@ function GameSlotRow({ participant }: GameSlotRowProps) {
           backgroundColor={theme.foreground}
           foregroundColor={theme.accent1}
           textColor={theme.background}
-          percent={participant.participation.dealt}
+          percent={participant.contributionPercentage.dealt}
           value={participant.contribution.dealt}
         />
       </td>
@@ -137,7 +136,7 @@ function GameSlotRow({ participant }: GameSlotRowProps) {
           backgroundColor={theme.foreground}
           foregroundColor={theme.red3}
           textColor={theme.background}
-          percent={participant.participation.damaged}
+          percent={participant.contributionPercentage.damaged}
           value={participant.contribution.damaged}
         />
       </td>
@@ -177,8 +176,7 @@ const GameSlotDetail = React.memo(function GameSlotDetail({
 
 const GameSlotSummary = React.memo(function GameSlotSummary({
   me,
-  participants,
-  contribution,
+  teamContribution,
 }: GameSlotSummaryProps) {
   const { theme } = useGlobalTheme();
   const championName = me.championName;
@@ -194,16 +192,14 @@ const GameSlotSummary = React.memo(function GameSlotSummary({
   const k = me.kills;
   const d = me.deaths;
   const a = me.assists;
-  const { dealtAverage, dealtMax, goldAverage, goldMax, deathAverage, deathMax, csAverage, csMax } =
-    contribution;
 
-  const dealMaxOffset = Math.abs(dealtMax - dealtAverage);
+  const dealMaxOffset = Math.abs(teamContribution.max.dealt - teamContribution.average.dealt);
   const dealValue = me.totalDamageDealtToChampions;
-  const goldMaxOffset = Math.abs(goldMax - goldAverage);
+  const goldMaxOffset = Math.abs(teamContribution.max.gold - teamContribution.average.gold);
   const goldValue = me.goldEarned;
-  const deathMaxOffset = Math.abs(deathMax - deathAverage);
+  const deathMaxOffset = Math.abs(teamContribution.max.death - teamContribution.average.death);
   const deathValue = me.deaths;
-  const csMaxOffset = Math.abs(csMax - csAverage);
+  const csMaxOffset = Math.abs(teamContribution.max.cs - teamContribution.average.cs);
   const csValue = me.totalMinionsKilled;
   const healValue = me.contribution.heal;
   const damagedValue = me.contribution.damaged;
@@ -245,29 +241,29 @@ const GameSlotSummary = React.memo(function GameSlotSummary({
       <div css={[style.item]}>
         <PercentageStatistics
           padding={6}
-          dealtPercent={me.participation.dealt}
+          dealtPercent={me.contributionPercentage.dealt}
           dealtAmount={dealValue}
-          healPercent={me.participation.heal}
+          healPercent={me.contributionPercentage.heal}
           healAmount={healValue}
-          damagedPercent={me.participation.damaged}
+          damagedPercent={me.contributionPercentage.damaged}
           damagedAmount={damagedValue}
-          deathPercent={me.participation.death}
+          deathPercent={me.contributionPercentage.death}
           deathAmount={deathValue}
           color={{ foreground: theme.foreground, background: theme.background }}
         />
       </div>
       <div css={[style.item]}>
         <RelativeStatistics
-          dealAverage={dealtAverage}
+          dealAverage={teamContribution.average.dealt}
           dealMaxOffset={dealMaxOffset}
           dealValue={dealValue}
-          goldAverage={goldAverage}
+          goldAverage={teamContribution.average.gold}
           goldMaxOffset={goldMaxOffset}
           goldValue={goldValue}
-          deathAverage={deathAverage}
+          deathAverage={teamContribution.average.death}
           deathMaxOffset={deathMaxOffset}
           deathValue={deathValue}
-          csAverage={csAverage}
+          csAverage={teamContribution.average.cs}
           csMaxOffset={csMaxOffset}
           csValue={csValue}
         />
@@ -295,7 +291,7 @@ function GameSlot({ matchData, puuid }: GameSlotProps) {
   const timeString = secondsToString(gameDuration);
 
   const contribution = matchData.info.teams.find((team) => team.teamId === me.teamId)?.contribution;
-  if (!contribution) throw new Error('contribution not exists');
+  if (!contribution) throw new Error('contribution does not exist');
 
   const [expand, setExpand] = useState<boolean>(false);
   const [rendered, setRendered] = useState<boolean>(false);
@@ -309,7 +305,7 @@ function GameSlot({ matchData, puuid }: GameSlotProps) {
           <div>{timeString}</div>
         </div>
         <div css={style.gameSummaryContainer}>
-          <GameSlotSummary me={me} participants={participants} contribution={contribution} />
+          <GameSlotSummary me={me} teamContribution={contribution} />
         </div>
         <div
           css={style.expand}

--- a/client/global.d.ts
+++ b/client/global.d.ts
@@ -105,7 +105,7 @@ interface Participant {
   commandPings: number;
   consumablesPurchased: number;
   contribution: ParticipantContribution;
-  participation: ParticipantParticipation;
+  contributionPercentage: ParticipantParticipation;
   damageDealtToBuildings: number;
   damageDealtToObjectives: number;
   damageDealtToTurrets: number;

--- a/client/global.d.ts
+++ b/client/global.d.ts
@@ -73,39 +73,12 @@ interface ObjectiveInfo {
 }
 
 interface TeamContribution {
-  dealt: number;
-  damaged: number;
-  heal: number;
-  death: number;
-  gold: number;
-  cs: number;
-
-  dealtMax: number;
-  damagedMax: number;
-  healMax: number;
-  deathMax: number;
-  goldMax: number;
-  csMax: number;
-  killParticipationMax: number;
-
-  dealtAverage: number;
-  damagedAverage: number;
-  healAverage: number;
-  deathAverage: number;
-  goldAverage: number;
-  csAverage: number;
+  total: Contribution;
+  max: Contribution;
+  average: Contribution;
 }
 
-interface ParticipantContribution {
-  dealt: number;
-  damaged: number;
-  heal: number;
-  death: number;
-  gold: number;
-  cs: number;
-}
-
-interface ParticipantParticipation {
+interface Contribution {
   dealt: number;
   damaged: number;
   heal: number;

--- a/client/pages/summoners/[summonerName].tsx
+++ b/client/pages/summoners/[summonerName].tsx
@@ -85,12 +85,23 @@ export default function SearchPage() {
     (async () => {
       try {
         setSummonerProfile(await getSummonerProfile(summonerName));
-        setMatchIds((await getSummonerMatchIds(summonerName)).matchIds);
       } catch (e) {
         console.error(e);
       }
     })();
   }, [summonerName]);
+
+  useEffect(() => {
+    if (summonerProfile === null) return;
+
+    (async () => {
+      try {
+        setMatchIds((await getSummonerMatchIds(summonerProfile.puuid)).matchIds);
+      } catch (e) {
+        console.error(e);
+      }
+    })();
+  }, [summonerProfile]);
 
   useEffect(() => {
     const promises = matchIds.map((matchId) => getMatch(matchId));

--- a/client/utils/api.ts
+++ b/client/utils/api.ts
@@ -16,11 +16,9 @@ export const getSummonerProfile = async (
   ).data;
 };
 
-export const getSummonerMatchIds = async (
-  summonerName: string,
-): Promise<SummonerMatchIdsResponse> => {
+export const getSummonerMatchIds = async (puuid: string): Promise<SummonerMatchIdsResponse> => {
   return await (
-    await defaultAxiosInstance.get(`/summoners/${summonerName}/matches`)
+    await defaultAxiosInstance.get(`/matches/by-puuid/${puuid}`)
   ).data;
 };
 

--- a/client/utils/matchStatistic.ts
+++ b/client/utils/matchStatistic.ts
@@ -18,9 +18,9 @@ export function getMatchStatistic(match: Match, puuid: string) {
   };
 
   const myContribution = me.contribution;
-  const myParticipation = me.participation;
+  const myPercentage = me.contributionPercentage;
 
-  if (!myParticipation) throw new Error('Match 데이터 오류');
+  if (!myContribution || !myPercentage) throw new Error('Match 데이터 오류');
 
   return {
     win,
@@ -30,7 +30,7 @@ export function getMatchStatistic(match: Match, puuid: string) {
     assists,
     camp,
     myContribution,
-    myParticipation,
+    myPercentage,
   };
 }
 
@@ -74,20 +74,20 @@ export function getTotalMatchStatistics(matchStatistic: { [index: string]: Match
     camp.blue += matchStatistic[matchId].camp.blue;
     camp.red += matchStatistic[matchId].camp.red;
 
-    gameContribution.dealt += matchStatistic[matchId].myParticipation.dealt;
-    gameContribution.damaged += matchStatistic[matchId].myParticipation.damaged;
-    gameContribution.heal += matchStatistic[matchId].myParticipation.heal;
-    gameContribution.death += matchStatistic[matchId].myParticipation.death;
-    kda.killContribution += matchStatistic[matchId].myParticipation.kill;
+    gameContribution.dealt += matchStatistic[matchId].myPercentage.dealt;
+    gameContribution.damaged += matchStatistic[matchId].myPercentage.damaged;
+    gameContribution.heal += matchStatistic[matchId].myPercentage.heal;
+    gameContribution.death += matchStatistic[matchId].myPercentage.death;
+    kda.killContribution += matchStatistic[matchId].myPercentage.kill;
   }
 
   const count = Object.keys(matchStatistic).length;
 
-  kda.killContribution = kda.killContribution / count;
-  gameContribution.dealt = gameContribution.dealt / count;
-  gameContribution.heal = gameContribution.heal / count;
-  gameContribution.damaged = gameContribution.damaged / count;
-  gameContribution.death = gameContribution.death / count;
+  kda.killContribution /= count;
+  gameContribution.dealt /= count;
+  gameContribution.heal /= count;
+  gameContribution.damaged /= count;
+  gameContribution.death /= count;
 
   return {
     winRate,

--- a/server/src/matches/dtos/get-puuid.dto.ts
+++ b/server/src/matches/dtos/get-puuid.dto.ts
@@ -1,0 +1,6 @@
+import { IsString } from 'class-validator';
+
+export class GetPuuidParam {
+  @IsString()
+  puuid: string;
+}

--- a/server/src/matches/dtos/post-puuid.dto.ts
+++ b/server/src/matches/dtos/post-puuid.dto.ts
@@ -1,0 +1,7 @@
+import { IsNumber, IsOptional } from 'class-validator';
+
+export class PostPuuidQuery {
+  @IsNumber()
+  @IsOptional()
+  after?: number;
+}

--- a/server/src/matches/matches.controller.ts
+++ b/server/src/matches/matches.controller.ts
@@ -1,18 +1,25 @@
-import { Controller, Get, Param, Post } from '@nestjs/common';
+import { Controller, Get, Param, Post, Query } from '@nestjs/common';
 import { GetMatchIdParam } from './dtos/get-matchId.dto';
+import { GetPuuidParam } from './dtos/get-puuid.dto';
+import { PostPuuidQuery } from './dtos/post-puuid.dto';
 import { MatchesService } from './matches.service';
 
 @Controller('matches')
 export class MatchesController {
   constructor(private readonly matchesService: MatchesService) {}
 
+  @Get('/by-puuid/:puuid')
+  async findAll(@Param() param: GetPuuidParam) {
+    return await this.matchesService.findAll(param.puuid);
+  }
+
+  @Post('/by-puuid/:puuid')
+  async updateMany(@Param() param: GetPuuidParam, @Query() query: PostPuuidQuery) {
+    return await this.matchesService.updateMany(param.puuid, query.after);
+  }
+
   @Get('/:matchId')
   async findOne(@Param() param: GetMatchIdParam) {
     return await this.matchesService.findOne(param.matchId);
-  }
-
-  @Post('/:matchId')
-  async updateOne(@Param() param: GetMatchIdParam) {
-    return await this.matchesService.updateOne(param.matchId);
   }
 }

--- a/server/src/matches/schemas/match.schema.ts
+++ b/server/src/matches/schemas/match.schema.ts
@@ -415,53 +415,30 @@ class Perks {
 const perksSchema = SchemaFactory.createForClass(Perks);
 
 @Schema({ id: false, _id: false })
-class ParticipantParticipation {
+export class Contribution {
   @Prop({ required: true })
-  dealt: number;
+  dealt: number = 0;
 
   @Prop({ required: true })
-  damaged: number;
+  damaged: number = 0;
 
   @Prop({ required: true })
-  heal: number;
+  heal: number = 0;
 
   @Prop({ required: true })
-  death: number;
+  death: number = 0;
 
   @Prop({ required: true })
-  gold: number;
+  gold: number = 0;
 
   @Prop({ required: true })
-  cs: number;
+  cs: number = 0;
 
   @Prop({ required: true })
-  kill: number;
+  kill: number = 0;
 }
 
-const participantParticipationSchema = SchemaFactory.createForClass(ParticipantParticipation);
-
-@Schema({ id: false, _id: false })
-class ParticipantContribution {
-  @Prop({ required: true })
-  dealt: number;
-
-  @Prop({ required: true })
-  damaged: number;
-
-  @Prop({ required: true })
-  heal: number;
-
-  @Prop({ required: true })
-  death: number;
-
-  @Prop({ required: true })
-  gold: number;
-
-  @Prop({ required: true })
-  cs: number;
-}
-
-const participantContributionSchema = SchemaFactory.createForClass(ParticipantContribution);
+const contributionSchema = SchemaFactory.createForClass(Contribution);
 
 @Schema({ id: false, _id: false })
 class Participant {
@@ -510,11 +487,11 @@ class Participant {
   @Prop({ required: true })
   consumablesPurchased: number;
 
-  @Prop({ required: true, type: participantParticipationSchema })
-  contribution: ParticipantContribution;
+  @Prop({ required: true, type: contributionSchema })
+  contribution: Contribution;
 
-  @Prop({ required: true, type: participantParticipationSchema })
-  participation: ParticipantParticipation;
+  @Prop({ required: true, type: contributionSchema })
+  contributionPercentage: Contribution;
 
   @Prop({ required: true })
   damageDealtToBuildings: number;
@@ -839,62 +816,14 @@ const participantSchema = SchemaFactory.createForClass(Participant);
 
 @Schema({ id: false, _id: false })
 export class TeamContribution {
-  @Prop({ required: true })
-  dealt: number;
+  @Prop({ required: true, type: contributionSchema })
+  total: Contribution = new Contribution();
 
-  @Prop({ required: true })
-  damaged: number;
+  @Prop({ required: true, type: contributionSchema })
+  max: Contribution = new Contribution();
 
-  @Prop({ required: true })
-  heal: number;
-
-  @Prop({ required: true })
-  death: number;
-
-  @Prop({ required: true })
-  gold: number;
-
-  @Prop({ required: true })
-  cs: number;
-
-  @Prop({ required: true })
-  dealtMax: number;
-
-  @Prop({ required: true })
-  damagedMax: number;
-
-  @Prop({ required: true })
-  healMax: number;
-
-  @Prop({ required: true })
-  deathMax: number;
-
-  @Prop({ required: true })
-  goldMax: number;
-
-  @Prop({ required: true })
-  csMax: number;
-
-  @Prop({ required: true })
-  killParticipationMax: number;
-
-  @Prop({ required: true })
-  dealtAverage: number;
-
-  @Prop({ required: true })
-  damagedAverage: number;
-
-  @Prop({ required: true })
-  healAverage: number;
-
-  @Prop({ required: true })
-  deathAverage: number;
-
-  @Prop({ required: true })
-  goldAverage: number;
-
-  @Prop({ required: true })
-  csAverage: number;
+  @Prop({ required: true, type: contributionSchema })
+  average: Contribution = new Contribution();
 }
 
 const teamContributionSchema = SchemaFactory.createForClass(TeamContribution);

--- a/server/src/riot.api/interface/riot.match.interface.ts
+++ b/server/src/riot.api/interface/riot.match.interface.ts
@@ -26,7 +26,6 @@ interface Team {
   objectives: Objectives;
   teamId: number;
   win: boolean;
-  contribution: TeamContribution;
 }
 
 interface Objectives {
@@ -41,30 +40,6 @@ interface Objectives {
 interface ObjectiveInfo {
   first: boolean;
   kills: number;
-}
-
-interface TeamContribution {
-  dealt: number;
-  damaged: number;
-  heal: number;
-  death: number;
-  gold: number;
-  cs: number;
-
-  dealtMax: number;
-  damagedMax: number;
-  healMax: number;
-  deathMax: number;
-  goldMax: number;
-  csMax: number;
-  killParticipationMax: number;
-
-  dealtAverage: number;
-  damagedAverage: number;
-  healAverage: number;
-  deathAverage: number;
-  goldAverage: number;
-  csAverage: number;
 }
 
 interface Participant {

--- a/server/src/riot.api/riot.api.service.ts
+++ b/server/src/riot.api/riot.api.service.ts
@@ -77,4 +77,14 @@ export class RiotApiService {
       )
     )?.data;
   }
+
+  async getMatchesByPuuid(puuid: string, after: number, count: number) {
+    return (
+      await this.call<string[]>(
+        `https://asia.api.riotgames.com/lol/match/v5/matches/by-puuid/${puuid}/ids?${
+          after && `endTime=${after}`
+        }&queue=450&start=0&count=${count}`,
+      )
+    )?.data;
+  }
 }


### PR DESCRIPTION
## 개요
- #167

## 작업사항
- Match의 기여도 저장 방식 재정의
  - 기존
    - `participant.contribution` 에 값 저장
    - `participant.participation` 에 퍼센티지 저장
    - `team.contribution`에 max, average, total 모두 저장
  - 수정
    - `participant.contribution` 에 값 저장
    - `participant.participantionPercentage` 에 퍼센티지 저장
    - `team.contribution.max`,  `team.contribution.average`,  `team.contribution.total` 에 각각 저장
  - 같은 자료형으로 통일 : `Participation`
- BE
  - GET /matches/by-puuid/:puuid
  - POST /matches/by-puuid/:puuid
- FE
  - BE 변경사항에 맞게 수정
    - gameSlot
    - matchStatistic api
