### PR TITLE
RiotAPI, 소환사 검색 오류 해결

### DIFF
--- a/client/pages/summoners/[summonerName].tsx
+++ b/client/pages/summoners/[summonerName].tsx
@@ -69,6 +69,11 @@ export default function SearchPage() {
   const handleSearch = () => {
     if (searchText === '') return;
 
+    setMatchIds([]);
+    setMatches([]);
+    setMatchStatistics(null);
+    setTotalStatistics(null);
+
     router.push(`/summoners/${searchText}`);
   };
 
@@ -76,6 +81,7 @@ export default function SearchPage() {
     const query = router.query;
     if (typeof query.summonerName === 'string') {
       setSummonerName(query.summonerName);
+      setSearchText(query.summonerName);
     }
   }, [router.isReady, router.query]);
 

--- a/server/src/riot.api/riot.api.service.ts
+++ b/server/src/riot.api/riot.api.service.ts
@@ -1,7 +1,7 @@
 import { HttpService } from '@nestjs/axios';
-import { HttpStatus, Injectable } from '@nestjs/common';
+import { HttpStatus, Injectable, Logger } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
-import { AxiosError, HttpStatusCode } from 'axios';
+import { AxiosError } from 'axios';
 import { RiotApiException } from './definition/riot.api.exception';
 import { RiotChallengeResponse, RoitSummonerResponse } from './interface';
 import { RiotMatchResponse } from './interface/riot.match.interface';
@@ -9,6 +9,7 @@ import { RiotMatchResponse } from './interface/riot.match.interface';
 @Injectable()
 export class RiotApiService {
   apiKey: string;
+  private readonly logger = new Logger(RiotApiService.name);
 
   constructor(
     private readonly httpService: HttpService,
@@ -38,7 +39,8 @@ export class RiotApiService {
           HttpStatus.GATEWAY_TIMEOUT,
         ];
 
-        if (serviceUnavailableCodes.includes(+error.code)) {
+        if (serviceUnavailableCodes.includes(+error.response?.status)) {
+          this.logger.error(`RoitAPI Error: ${error.message}`);
           throw new RiotApiException(+error.code, error.message);
         }
 


### PR DESCRIPTION
## 개요
- #176 
- #173 

## 작업사항
- RiotAPI 오류시 재대로 동작하지 않는 문제 해결
- 다른 소환사 검색했을 때 오류 해결
