### PR TITLE
첫 검색 시 더보기 버튼 보이지 않도록 수정

### DIFF
--- a/client/pages/summoners/[summonerName].tsx
+++ b/client/pages/summoners/[summonerName].tsx
@@ -230,7 +230,7 @@ function SummonerProfilePanel({ summonerName }: SummonerProfilePanelProps) {
             puuid={summonerProfile.puuid}
           />
         ))}
-        {matches && (
+        {matches.length !== 0 && (
           <Button
             width={'100%'}
             enabled={!fetching}


### PR DESCRIPTION
## 개요
- #204 

## 작업사항
- 매치 데이터가 없을 때 (DB에 소환사 데이터만 있을 때) 더보기 버튼 보이지 않도록 수정
