### PR TITLE
fix: percentageBar 마우스 이벤트

### DIFF
--- a/client/components/PercentageBar/index.tsx
+++ b/client/components/PercentageBar/index.tsx
@@ -23,18 +23,16 @@ const style = {
     background-color: ${color};
   `,
   text: css`
+    pointer-events: none;
     line-height: 16px;
     color: black;
     position: absolute;
     width: 100%;
     height: 100%;
-    font-size: 13px;
+    font-size: 12px;
     text-align: center;
     vertical-align: middle;
-  `,
-  span: css`
     color: white;
-    border-radius: 10px;
   `,
 };
 
@@ -63,9 +61,8 @@ export default function PercentageBar({ amounts, colors }: PercentageBarProps) {
             onMouseLeave={() => setText('')}
           ></div>
         ))}
-      <div css={style.text}>
-        <span css={style.span}>&nbsp; {text} &nbsp;</span>
-      </div>
+
+      <div css={style.text}>{text}</div>
     </div>
   );
 }


### PR DESCRIPTION
## 개요
- #158

## 작업사항
- overlaying element를 `pointer-events:none;`으로 설정하면, 포인터 이벤트가 그 밑의 element로 전달됨
