### PR TITLE
fix: 챌린지 preference 없는 경우 처리 (Close #209)

### DIFF
--- a/server/src/riot.api/interface/riot.challenge.interface.ts
+++ b/server/src/riot.api/interface/riot.challenge.interface.ts
@@ -6,9 +6,9 @@ export interface RiotChallengeResponse {
 }
 
 interface Preferences {
-  bannerAccent: string;
-  title: string;
-  challengeIds: number[];
+  bannerAccent?: string;
+  title?: string;
+  challengeIds?: number[];
 }
 
 interface Challenge {

--- a/server/src/summoners/summoners.service.ts
+++ b/server/src/summoners/summoners.service.ts
@@ -29,8 +29,8 @@ export class SummonersService {
 
     const challenges = await this.riotApiService.getChallenges(summonerFromRiot.puuid);
     const userChallenges = challenges.preferences.challengeIds
-      .map((challengeId) => challenges.challenges.find((c) => c.challengeId === challengeId))
-      .filter((c) => !!c);
+      ?.map((challengeId) => challenges.challenges.find((c) => c.challengeId === challengeId))
+      ?.filter((c) => !!c);
 
     await this.summonerModel.updateOne(
       { puuid: summonerFromRiot.puuid },
@@ -39,7 +39,7 @@ export class SummonersService {
         level: summonerFromRiot.summonerLevel,
         profileIconId: summonerFromRiot.profileIconId,
         puuid: summonerFromRiot.puuid,
-        challenges: [...userChallenges],
+        challenges: [...(userChallenges ?? [])],
       },
       { upsert: true },
     );


### PR DESCRIPTION
## 개요
- #209 

## 작업사항
- 챌린지 preference가 없는 경우 처리
  - preference interface 수정
  - 없을 경우 아무것도 넣지 않도록
