### PR TITLE
fix: 챔피언 이름과 이미지 이름이 다른 경우 처리 (Close #205)

### DIFF
--- a/client/components/ChampionPic/index.tsx
+++ b/client/components/ChampionPic/index.tsx
@@ -1,11 +1,12 @@
 import Image from 'next/image';
 import { css } from '@emotion/react';
-import { useRecoilValueLoadable } from 'recoil';
-import { ddragonVersion } from '../../states/ddragon';
-import { DDRAGON_BASE_URL, DEAFULT_PLACEHOLDER } from '../../utils/ddragon';
+import { useRecoilValue, useRecoilValueLoadable } from 'recoil';
+import { ddragonChampions, ddragonVersion, ddragonVersions } from '../../states/ddragon';
+import { DDRAGON_BASE_URL, DEAFULT_PLACEHOLDER, getMajorVersion } from '../../utils/ddragon';
 
 interface ChampionPicProps {
-  championName: string;
+  championKey: string | number;
+  version: string;
   width: number;
   height: number;
   shape?: 'rectangle' | 'round';
@@ -18,13 +19,26 @@ const style = {
   `,
 };
 
-function ChampionPic({ championName, width, height, shape = 'round' }: ChampionPicProps) {
-  const version = useRecoilValueLoadable(ddragonVersion);
+function ChampionPic({ championKey, version, width, height, shape = 'round' }: ChampionPicProps) {
+  const versions = useRecoilValue(ddragonVersions);
+  const championDic = useRecoilValueLoadable(
+    ddragonChampions(getMajorVersion(versions, version) || '13.1.1'),
+  );
   const src =
-    version.state === 'hasValue'
-      ? `${DDRAGON_BASE_URL}${version.contents}/img/champion/${championName}.png`
+    championDic.state === 'hasValue'
+      ? `${DDRAGON_BASE_URL}${getMajorVersion(versions, version) || '13.1.1'}/img/champion/${
+          championDic.contents[championKey]
+        }.png`
       : DEAFULT_PLACEHOLDER;
-  return <Image css={style[shape]} src={src} width={width} height={height} alt={championName} />;
+  return (
+    <Image
+      css={style[shape]}
+      src={src}
+      width={width}
+      height={height}
+      alt={championDic.contents[championKey]}
+    />
+  );
 }
 
 export default ChampionPic;

--- a/client/components/GameSlot/index.tsx
+++ b/client/components/GameSlot/index.tsx
@@ -80,7 +80,12 @@ function GameSlotRow({ version, participant }: GameSlotRowProps) {
       <td>
         <div css={detailStyle.champion}>
           <div css={detailStyle.level}>{participant.champLevel}</div>
-          <ChampionPic championName={participant.championName} width={32} height={32} />
+          <ChampionPic
+            championKey={participant.championId}
+            version={version}
+            width={32}
+            height={32}
+          />
         </div>
         <div css={detailStyle.name}>{participant.summonerName}</div>
       </td>
@@ -188,7 +193,7 @@ const GameSlotSummary = React.memo(function GameSlotSummary({
   teamContribution,
 }: GameSlotSummaryProps) {
   const { theme } = useGlobalTheme();
-  const championName = me.championName;
+  const championId = me.championId;
   const level = me.champLevel;
   const spells = [me.summoner1Id, me.summoner2Id];
   const items = [me.item0, me.item1, me.item2, me.item3, me.item4, me.item5];
@@ -222,7 +227,7 @@ const GameSlotSummary = React.memo(function GameSlotSummary({
     <div css={style.gameSummary}>
       <div css={[style.item, style.champion]}>
         <div css={[style.bottomRight, style.level]}>{level}</div>
-        <ChampionPic championName={championName} width={80} height={80} />
+        <ChampionPic championKey={championId} version={version} width={80} height={80} />
       </div>
       <div css={[style.item]}>
         <div css={style.summary}>

--- a/client/states/ddragon.ts
+++ b/client/states/ddragon.ts
@@ -18,12 +18,23 @@ export const ddragonRegion = atom<string>({
   default: 'ko_KR',
 });
 
-export const ddragonChampions = selectorFamily<Champions, string>({
+interface ChampionDictionary {
+  [key: string]: string;
+}
+
+export const ddragonChampions = selectorFamily<ChampionDictionary, string>({
   key: 'ddragonChampions',
   get:
     (version) =>
-    async ({ get }) => {
-      return (await getChampionDdragon(version, get(ddragonRegion))).data;
+    async ({}) => {
+      const champions = (await getChampionDdragon(version, 'en_US')).data;
+      const result: ChampionDictionary = {};
+
+      for (const key of Object.keys(champions)) {
+        result[champions[key].key] = champions[key].id;
+      }
+
+      return result;
     },
 });
 


### PR DESCRIPTION
## 개요
- #205

## 작업사항
- match 데이터의 챔피언 이름과 이미지 이름이 다른 경우 처리
  - 모든 챔피언을 match데이터의 id(key)를 이용해 해당 버전의 champion.json의 id(파일명)을 가져와 사용하도록 수정
