### PR TITLE
대소문자 구분 없이 검색 가능하도록 수정 (Close #250)

### DIFF
--- a/client/global.d.ts
+++ b/client/global.d.ts
@@ -10,7 +10,7 @@ interface Challenge {
 type SummonerProfileResponse = SummonerProfile;
 
 interface SummonerProfile {
-  userName: string;
+  name: string;
   level: number;
   id: string;
   puuid: string;

--- a/client/pages/summoners/[summonerName].tsx
+++ b/client/pages/summoners/[summonerName].tsx
@@ -236,7 +236,7 @@ function SummonerProfilePanel({ summonerName }: SummonerProfilePanelProps) {
       <div css={style.profile}>
         <SummonerProfileCard
           profileIconId={summonerProfile.profileIconId}
-          summonerName={summonerName}
+          summonerName={summonerProfile.name}
           summonerLevel={summonerProfile.level}
           modifiedAt={new Date(summonerProfile.updatedAt).getTime()}
           challenges={summonerProfile.challenges}

--- a/server/src/matches/matches.service.ts
+++ b/server/src/matches/matches.service.ts
@@ -36,7 +36,7 @@ export class MatchesService {
     };
   }
 
-  async updateMany(puuid: string, after: number) {
+  async updateMany(puuid: string, after?: number) {
     const updateSummoner = await this.summonerModel
       .updateOne({ puuid: puuid, isFetching: false }, { $set: { isFetching: true } })
       .lean();

--- a/server/src/summoners/summoners.service.ts
+++ b/server/src/summoners/summoners.service.ts
@@ -12,7 +12,9 @@ export class SummonersService {
   ) {}
 
   async findOne(summonerName: string) {
-    const summoner = await this.summonerModel.findOne({ name: summonerName }).lean();
+    const summoner = await this.summonerModel
+      .findOne({ name: { $regex: new RegExp(summonerName, 'i') } })
+      .lean();
 
     if (!summoner) throw new NotFoundException('해당 소환사가 없습니다.');
 

--- a/server/src/summoners/summoners.service.ts
+++ b/server/src/summoners/summoners.service.ts
@@ -22,7 +22,9 @@ export class SummonersService {
   }
 
   async update(summonerName: string) {
-    const summonerFromDb = await this.summonerModel.findOne({ name: summonerName }).lean();
+    const summonerFromDb = await this.summonerModel
+      .findOne({ name: { $regex: new RegExp(summonerName, 'i') } })
+      .lean();
     const summonerFromRiot = await (!!summonerFromDb
       ? this.riotApiService.getSummonerByPuuid(summonerFromDb.puuid)
       : this.riotApiService.getSummonerByName(summonerName));


### PR DESCRIPTION
## 개요
- #250 

## 작업사항
- FE BE에서 받아온 이름으로 표시
- BE 정규식으로 대소문자 무시
- BE DB에서 받아온 이름으로 RiotAPI 호출
