### PR TITLE
Polling 방식 변경

### DIFF
--- a/client/global.d.ts
+++ b/client/global.d.ts
@@ -15,9 +15,12 @@ interface SummonerProfile {
   id: string;
   puuid: string;
   profileIconId: number;
-  isFetching: boolean;
   challenges: Challenge[];
-  updatedAt: string;
+  updatedAt: Date;
+}
+
+interface CreatedResponse {
+  startedAt: Date;
 }
 
 type SummonerMatchIds = number[];

--- a/client/pages/summoners/[summonerName].tsx
+++ b/client/pages/summoners/[summonerName].tsx
@@ -117,7 +117,7 @@ function SummonerProfilePanel({ summonerName, setSummonerNotFound }: SummonerPro
   const [matches, setMatches] = useState<Match[]>([]);
   const [matchStatistics, setMatchStatistics] = useState<{ [key: string]: MatchStatistic }>({});
   const [totalStatistics, setTotalStatistics] = useState<TotalStatistic | null>(null);
-  const [fetching, setFetching] = useState<boolean>(false);
+  const [fetching, setFetching] = useState<Date | null>(null);
   const [loadMore, setLoadMore] = useState<boolean>(false);
   const [update, setUpdate] = useState<boolean>(false);
   const [scoreMultipliers, setScoreMultipliers] = useState<Contribution | null>(null);
@@ -125,7 +125,7 @@ function SummonerProfilePanel({ summonerName, setSummonerNotFound }: SummonerPro
   useEffect(() => {
     async function tick() {
       const newSummonerProfile = await getSummonerProfile(summonerName);
-      if (!newSummonerProfile.isFetching) {
+      if (fetching != newSummonerProfile.updatedAt) {
         setSummonerProfile(newSummonerProfile);
         const lastMatchId = matches.length ? matches[matches.length - 1].info.gameId : 0;
 
@@ -144,12 +144,12 @@ function SummonerProfilePanel({ summonerName, setSummonerNotFound }: SummonerPro
         clearInterval(timer);
       };
     }
-  }, [loadMore, summonerName, matchIds, matches]);
+  }, [loadMore, summonerName, matchIds, matches, fetching]);
 
   useEffect(() => {
     async function tick() {
       const newSummonerProfile = await getSummonerProfile(summonerName);
-      if (!newSummonerProfile.isFetching) {
+      if (fetching != newSummonerProfile.updatedAt) {
         setSummonerProfile(newSummonerProfile);
         setMatches([]);
         setMatchIds((await getSummonerMatchIds(newSummonerProfile.puuid)).matchIds);
@@ -161,14 +161,14 @@ function SummonerProfilePanel({ summonerName, setSummonerNotFound }: SummonerPro
       const timer = setInterval(tick, 1000);
       return () => clearInterval(timer);
     }
-  }, [update, summonerName]);
+  }, [update, summonerName, fetching]);
 
   // on summoner change
   useEffect(() => {
     // reset previous summoner data
     setUpdate(false);
     setLoadMore(false);
-    setFetching(false);
+    setFetching(null);
     setTotalStatistics(defaultTotalStatistics);
     setSummonerProfile(null);
     setMatchIds([]);
@@ -236,7 +236,7 @@ function SummonerProfilePanel({ summonerName, setSummonerNotFound }: SummonerPro
     if (matchStatistics) {
       setTotalStatistics(getTotalMatchStatistics(matchStatistics));
     }
-    setFetching(false);
+    setFetching(null);
   }, [matchStatistics]);
 
   // before loading router
@@ -258,16 +258,15 @@ function SummonerProfilePanel({ summonerName, setSummonerNotFound }: SummonerPro
           challenges={summonerProfile.challenges}
           onClick={async () => {
             try {
-              setFetching(true);
-              await requestFetchSummonerMatches(summonerProfile.puuid);
+              setFetching((await requestFetchSummonerMatches(summonerProfile.puuid)).startedAt);
               setUpdate(true);
             } catch (e) {
               console.error(e);
               setUpdate(false);
-              setFetching(false);
+              setFetching(null);
             }
           }}
-          fetching={fetching}
+          fetching={fetching !== null}
         />
         <SummonerStatCard
           winRate={winRate}
@@ -290,16 +289,19 @@ function SummonerProfilePanel({ summonerName, setSummonerNotFound }: SummonerPro
             enabled={!fetching}
             onClick={async () => {
               try {
-                setFetching(true);
-                await requestFetchSummonerMatches(
-                  summonerProfile.puuid,
-                  Math.floor(matches[matches.length - 1].info.gameCreation / 1000),
+                setFetching(
+                  (
+                    await requestFetchSummonerMatches(
+                      summonerProfile.puuid,
+                      Math.floor(matches[matches.length - 1].info.gameCreation / 1000),
+                    )
+                  ).startedAt,
                 );
                 setLoadMore(true);
               } catch (e) {
                 console.error(e);
                 setLoadMore(false);
-                setFetching(false);
+                setFetching(null);
               }
             }}
           >

--- a/client/utils/api.ts
+++ b/client/utils/api.ts
@@ -36,10 +36,13 @@ export async function getSummonerMatchIds(
   ).data;
 }
 
-export async function requestFetchSummonerMatches(puuid: string, after?: number): Promise<number> {
+export async function requestFetchSummonerMatches(
+  puuid: string,
+  after?: number,
+): Promise<CreatedResponse> {
   return (
     await defaultAxiosInstance.post(`/matches/by-puuid/${puuid}${after ? `?after=${after}` : ''}`)
-  ).status;
+  ).data;
 }
 
 export async function getMatch(matchId: number): Promise<MatchResponse> {

--- a/server/src/summoners/schemas/summoner.schema.ts
+++ b/server/src/summoners/schemas/summoner.schema.ts
@@ -24,9 +24,6 @@ export class Summoner extends Document {
   @Prop({ default: new Date().getTime(), type: mongoose.Schema.Types.Date })
   updatedAt: Date;
 
-  @Prop({ required: true, default: false })
-  isFetching: boolean;
-
   @Prop({
     type: [
       {

--- a/server/src/summoners/test/summoners.mock.ts
+++ b/server/src/summoners/test/summoners.mock.ts
@@ -28,11 +28,10 @@ export const mockSummoner = {
       _id: '63c78c013b96d87cb690268d',
     },
   ],
-  isFetching: false,
   level: 123,
   name: 'dolphinlmg',
   profileIconId: 5528,
-  updatedAt: '2023-01-25T07:51:18.986Z',
+  updatedAt: new Date('2023-01-25T07:51:18.986Z'),
 };
 
 const riotApiResponse = {


### PR DESCRIPTION
## 개요
- #231

## 작업사항
- POST /matches/by-puuid/:puuid 에서 isFetching flag가 아닌 updatedAt을 기준으로 판단 (전적 갱신: 60초, 더보기: 1초)
