### PR TITLE
통계 계산시 total이 0인 경우 처리

### DIFF
--- a/client/utils/matchStatistic.ts
+++ b/client/utils/matchStatistic.ts
@@ -30,7 +30,7 @@ export function getMatchStatistic(match: Match, puuid: string) {
     .kills;
   const me = match.info.participants.find((participant) => participant.puuid === puuid);
 
-  if (!teamId || win === undefined || !totalKill || !me) throw new Error('Match 데이터 오류');
+  if (!teamId || win === undefined || !me) throw new Error('Match 데이터 오류');
 
   const { kills, deaths, assists } = me;
 

--- a/server/src/matches/matches.service.ts
+++ b/server/src/matches/matches.service.ts
@@ -1,6 +1,6 @@
 import { ForbiddenException, Injectable, Logger, NotFoundException } from '@nestjs/common';
 import { InjectModel } from '@nestjs/mongoose';
-import { Model } from 'mongoose';
+import { Model, MongooseError } from 'mongoose';
 import { PlayService } from '../play/play.service';
 import { RiotApiException } from '../riot.api/definition/riot.api.exception';
 import { RiotApiService } from '../riot.api/riot.api.service';
@@ -130,7 +130,15 @@ export class MatchesService {
           participant.contributionPercentageTotal = contributionPercentageTotal;
 
           // create play
-          await this.playService.create(participant.puuid, id, match.info.gameCreation);
+          try {
+            await this.playService.create(participant.puuid, id, match.info.gameCreation);
+          } catch (e) {
+            if (e.name === 'MongoServerError' && e.code === 11000) {
+              this.logger.error(e);
+            } else {
+              throw e;
+            }
+          }
         }
 
         // team contribution : average

--- a/server/src/matches/matches.service.ts
+++ b/server/src/matches/matches.service.ts
@@ -109,17 +109,21 @@ export class MatchesService {
 
           // personal participation statistics (percentage)
           contributionKeys.forEach((key) => {
+            // check zero
+            const teamContributionDivisor =
+              teamContribution.total[key] === 0 ? 1 : teamContribution.total[key];
+            const totalContributionDivisor =
+              match.info.teams[0].contribution.total[key] +
+                match.info.teams[1].contribution.total[key] ===
+              0
+                ? 1
+                : match.info.teams[0].contribution.total[key] +
+                  match.info.teams[1].contribution.total[key];
             // TODO: consider version & optimize : ex) make use of 'KillParticipation'
             contributionPercentage[key] =
-              Math.round((participant.contribution[key] / teamContribution.total[key]) * 1000) /
-              1000;
+              Math.round((participant.contribution[key] / teamContributionDivisor) * 1000) / 1000;
             contributionPercentageTotal[key] =
-              Math.round(
-                (participant.contribution[key] /
-                  (match.info.teams[0].contribution.total[key] +
-                    match.info.teams[1].contribution.total[key])) *
-                  1000,
-              ) / 1000;
+              Math.round((participant.contribution[key] / totalContributionDivisor) * 1000) / 1000;
           });
 
           participant.contributionPercentage = contributionPercentage;

--- a/server/src/matches/matches.service.ts
+++ b/server/src/matches/matches.service.ts
@@ -1,6 +1,6 @@
 import { ForbiddenException, Injectable, Logger, NotFoundException } from '@nestjs/common';
 import { InjectModel } from '@nestjs/mongoose';
-import { Model, MongooseError } from 'mongoose';
+import { Model } from 'mongoose';
 import { PlayService } from '../play/play.service';
 import { RiotApiException } from '../riot.api/definition/riot.api.exception';
 import { RiotApiService } from '../riot.api/riot.api.service';

--- a/server/src/matches/schemas/match.schema.ts
+++ b/server/src/matches/schemas/match.schema.ts
@@ -19,337 +19,337 @@ const metaDataSchema = SchemaFactory.createForClass(Metadata);
 
 @Schema({ id: false, _id: false })
 class Challenges {
-  @Prop({ required: true })
+  @Prop({ required: false })
   '12AssistStreakCount': number;
 
-  @Prop({ required: true })
+  @Prop({ required: false })
   abilityUses: number;
 
-  @Prop({ required: true })
+  @Prop({ required: false })
   acesBefore15Minutes: number;
 
-  @Prop({ required: true })
+  @Prop({ required: false })
   alliedJungleMonsterKills: number;
 
-  @Prop({ required: true })
+  @Prop({ required: false })
   baronTakedowns: number;
 
-  @Prop({ required: true })
+  @Prop({ required: false })
   blastConeOppositeOpponentCount: number;
 
-  @Prop({ required: true })
+  @Prop({ required: false })
   bountyGold: number;
 
-  @Prop({ required: true })
+  @Prop({ required: false })
   buffsStolen: number;
 
-  @Prop({ required: true })
+  @Prop({ required: false })
   completeSupportQuestInTime: number;
 
-  @Prop({ required: true })
+  @Prop({ required: false })
   controlWardsPlaced: number;
 
-  @Prop({ required: true })
+  @Prop({ required: false })
   damagePerMinute: number;
 
-  @Prop({ required: true })
+  @Prop({ required: false })
   damageTakenOnTeamPercentage: number;
 
-  @Prop({ required: true })
+  @Prop({ required: false })
   dancedWithRiftHerald: number;
 
-  @Prop({ required: true })
+  @Prop({ required: false })
   deathsByEnemyChamps: number;
 
-  @Prop({ required: true })
+  @Prop({ required: false })
   dodgeSkillShotsSmallWindow: number;
 
-  @Prop({ required: true })
+  @Prop({ required: false })
   doubleAces: number;
 
-  @Prop({ required: true })
+  @Prop({ required: false })
   dragonTakedowns: number;
 
-  @Prop({ required: true })
+  @Prop({ required: false })
   earlyLaningPhaseGoldExpAdvantage: number;
 
-  @Prop({ required: true })
+  @Prop({ required: false })
   effectiveHealAndShielding: number;
 
-  @Prop({ required: true })
+  @Prop({ required: false })
   elderDragonKillsWithOpposingSoul: number;
 
-  @Prop({ required: true })
+  @Prop({ required: false })
   elderDragonMultikills: number;
 
-  @Prop({ required: true })
+  @Prop({ required: false })
   enemyChampionImmobilizations: number;
 
-  @Prop({ required: true })
+  @Prop({ required: false })
   enemyJungleMonsterKills: number;
 
-  @Prop({ required: true })
+  @Prop({ required: false })
   epicMonsterKillsNearEnemyJungler: number;
 
-  @Prop({ required: true })
+  @Prop({ required: false })
   epicMonsterKillsWithin30SecondsOfSpawn: number;
 
-  @Prop({ required: true })
+  @Prop({ required: false })
   epicMonsterSteals: number;
 
-  @Prop({ required: true })
+  @Prop({ required: false })
   epicMonsterStolenWithoutSmite: number;
 
-  @Prop({ required: true })
+  @Prop({ required: false })
   firstTurretKilledTime?: number;
 
-  @Prop({ required: true })
+  @Prop({ required: false })
   flawlessAces: number;
 
-  @Prop({ required: true })
+  @Prop({ required: false })
   fullTeamTakedown: number;
 
-  @Prop({ required: true })
+  @Prop({ required: false })
   gameLength: number;
 
-  @Prop({ required: true })
+  @Prop({ required: false })
   getTakedownsInAllLanesEarlyJungleAsLaner: number;
 
-  @Prop({ required: true })
+  @Prop({ required: false })
   goldPerMinute: number;
 
-  @Prop({ required: true })
+  @Prop({ required: false })
   hadOpenNexus: number;
 
-  @Prop({ required: true })
+  @Prop({ required: false })
   highestCrowdControlScore?: number;
 
-  @Prop({ required: true })
+  @Prop({ required: false })
   immobilizeAndKillWithAlly: number;
 
-  @Prop({ required: true })
+  @Prop({ required: false })
   initialBuffCount: number;
 
-  @Prop({ required: true })
+  @Prop({ required: false })
   initialCrabCount: number;
 
-  @Prop({ required: true })
+  @Prop({ required: false })
   jungleCsBefore10Minutes: number;
 
-  @Prop({ required: true })
+  @Prop({ required: false })
   junglerTakedownsNearDamagedEpicMonster: number;
 
-  @Prop({ required: true })
+  @Prop({ required: false })
   kTurretsDestroyedBeforePlatesFall: number;
 
-  @Prop({ required: true })
+  @Prop({ required: false })
   kda: number;
 
-  @Prop({ required: true })
+  @Prop({ required: false })
   killAfterHiddenWithAlly: number;
 
-  @Prop({ required: true })
+  @Prop({ required: false })
   killParticipation: number;
 
-  @Prop({ required: true })
+  @Prop({ required: false })
   killedChampTookFullTeamDamageSurvived: number;
 
-  @Prop({ required: true })
+  @Prop({ required: false })
   killsNearEnemyTurret: number;
 
-  @Prop({ required: true })
+  @Prop({ required: false })
   killsOnOtherLanesEarlyJungleAsLaner: number;
 
-  @Prop({ required: true })
+  @Prop({ required: false })
   killsOnRecentlyHealedByAramPack: number;
 
-  @Prop({ required: true })
+  @Prop({ required: false })
   killsUnderOwnTurret: number;
 
-  @Prop({ required: true })
+  @Prop({ required: false })
   killsWithHelpFromEpicMonster: number;
 
-  @Prop({ required: true })
+  @Prop({ required: false })
   knockEnemyIntoTeamAndKill: number;
 
-  @Prop({ required: true })
+  @Prop({ required: false })
   landSkillShotsEarlyGame: number;
 
-  @Prop({ required: true })
+  @Prop({ required: false })
   laneMinionsFirst10Minutes: number;
 
-  @Prop({ required: true })
+  @Prop({ required: false })
   legendaryCount: number;
 
-  @Prop({ required: true })
+  @Prop({ required: false })
   lostAnInhibitor: number;
 
-  @Prop({ required: true })
+  @Prop({ required: false })
   maxCsAdvantageOnLaneOpponent: number;
 
-  @Prop({ required: true })
+  @Prop({ required: false })
   maxKillDeficit: number;
 
-  @Prop({ required: true })
+  @Prop({ required: false })
   maxLevelLeadLaneOpponent: number;
 
-  @Prop({ required: true })
+  @Prop({ required: false })
   moreEnemyJungleThanOpponent: number;
 
-  @Prop({ required: true })
+  @Prop({ required: false })
   multiKillOneSpell: number;
 
-  @Prop({ required: true })
+  @Prop({ required: false })
   multiTurretRiftHeraldCount: number;
 
-  @Prop({ required: true })
+  @Prop({ required: false })
   multikills: number;
 
-  @Prop({ required: true })
+  @Prop({ required: false })
   multikillsAfterAggressiveFlash: number;
 
-  @Prop({ required: true })
+  @Prop({ required: false })
   mythicItemUsed?: number;
 
-  @Prop({ required: true })
+  @Prop({ required: false })
   outerTurretExecutesBefore10Minutes: number;
 
-  @Prop({ required: true })
+  @Prop({ required: false })
   outnumberedKills: number;
 
-  @Prop({ required: true })
+  @Prop({ required: false })
   outnumberedNexusKill: number;
 
-  @Prop({ required: true })
+  @Prop({ required: false })
   perfectDragonSoulsTaken: number;
 
-  @Prop({ required: true })
+  @Prop({ required: false })
   perfectGame: number;
 
-  @Prop({ required: true })
+  @Prop({ required: false })
   pickKillWithAlly: number;
 
-  @Prop({ required: true })
+  @Prop({ required: false })
   poroExplosions: number;
 
-  @Prop({ required: true })
+  @Prop({ required: false })
   quickCleanse: number;
 
-  @Prop({ required: true })
+  @Prop({ required: false })
   quickFirstTurret: number;
 
-  @Prop({ required: true })
+  @Prop({ required: false })
   quickSoloKills: number;
 
-  @Prop({ required: true })
+  @Prop({ required: false })
   riftHeraldTakedowns: number;
 
-  @Prop({ required: true })
+  @Prop({ required: false })
   saveAllyFromDeath: number;
 
-  @Prop({ required: true })
+  @Prop({ required: false })
   scuttleCrabKills: number;
 
-  @Prop({ required: true })
+  @Prop({ required: false })
   shortestTimeToAceFromFirstTakedown?: number;
 
-  @Prop({ required: true })
+  @Prop({ required: false })
   skillshotsDodged: number;
 
-  @Prop({ required: true })
+  @Prop({ required: false })
   skillshotsHit: number;
 
-  @Prop({ required: true })
+  @Prop({ required: false })
   snowballsHit: number;
 
-  @Prop({ required: true })
+  @Prop({ required: false })
   soloBaronKills: number;
 
-  @Prop({ required: true })
+  @Prop({ required: false })
   soloKills: number;
 
-  @Prop({ required: true })
+  @Prop({ required: false })
   stealthWardsPlaced: number;
 
-  @Prop({ required: true })
+  @Prop({ required: false })
   survivedSingleDigitHpCount: number;
 
-  @Prop({ required: true })
+  @Prop({ required: false })
   survivedThreeImmobilizesInFight: number;
 
-  @Prop({ required: true })
+  @Prop({ required: false })
   takedownOnFirstTurret: number;
 
-  @Prop({ required: true })
+  @Prop({ required: false })
   takedowns: number;
 
-  @Prop({ required: true })
+  @Prop({ required: false })
   takedownsAfterGainingLevelAdvantage: number;
 
-  @Prop({ required: true })
+  @Prop({ required: false })
   takedownsBeforeJungleMinionSpawn: number;
 
-  @Prop({ required: true })
+  @Prop({ required: false })
   takedownsFirstXMinutes: number;
 
-  @Prop({ required: true })
+  @Prop({ required: false })
   takedownsInAlcove: number;
 
-  @Prop({ required: true })
+  @Prop({ required: false })
   takedownsInEnemyFountain: number;
 
-  @Prop({ required: true })
+  @Prop({ required: false })
   teamBaronKills: number;
 
-  @Prop({ required: true })
+  @Prop({ required: false })
   teamDamagePercentage: number;
 
-  @Prop({ required: true })
+  @Prop({ required: false })
   teamElderDragonKills: number;
 
-  @Prop({ required: true })
+  @Prop({ required: false })
   teamRiftHeraldKills: number;
 
-  @Prop({ required: true })
+  @Prop({ required: false })
   threeWardsOneSweeperCount: number;
 
-  @Prop({ required: true })
+  @Prop({ required: false })
   tookLargeDamageSurvived: number;
 
-  @Prop({ required: true })
+  @Prop({ required: false })
   turretPlatesTaken: number;
 
-  @Prop({ required: true })
+  @Prop({ required: false })
   turretTakedowns: number;
 
-  @Prop({ required: true })
+  @Prop({ required: false })
   turretsTakenWithRiftHerald: number;
 
-  @Prop({ required: true })
+  @Prop({ required: false })
   twentyMinionsIn3SecondsCount: number;
 
-  @Prop({ required: true })
+  @Prop({ required: false })
   unseenRecalls: number;
 
-  @Prop({ required: true })
+  @Prop({ required: false })
   visionScoreAdvantageLaneOpponent: number;
 
-  @Prop({ required: true })
+  @Prop({ required: false })
   visionScorePerMinute: number;
 
-  @Prop({ required: true })
+  @Prop({ required: false })
   wardTakedowns: number;
 
-  @Prop({ required: true })
+  @Prop({ required: false })
   wardTakedownsBefore20M: number;
 
-  @Prop({ required: true })
+  @Prop({ required: false })
   wardsGuarded: number;
 
-  @Prop({ required: true })
+  @Prop({ required: false })
   killingSprees?: number;
 
-  @Prop({ required: true })
+  @Prop({ required: false })
   highestChampionDamage?: number;
 }
 

--- a/server/src/play/play.service.ts
+++ b/server/src/play/play.service.ts
@@ -24,10 +24,13 @@ export class PlayService {
   }
 
   async create(puuid: string, matchId: number, gameCreation: number) {
-    await this.playModel.create({
-      puuid: puuid,
-      matchId: matchId,
-      gameCreation: gameCreation,
-    });
+    await this.playModel.create(
+      {
+        puuid: puuid,
+        matchId: matchId,
+        gameCreation: gameCreation,
+      },
+      { upsert: true },
+    );
   }
 }

--- a/server/src/play/play.service.ts
+++ b/server/src/play/play.service.ts
@@ -24,13 +24,10 @@ export class PlayService {
   }
 
   async create(puuid: string, matchId: number, gameCreation: number) {
-    await this.playModel.create(
-      {
-        puuid: puuid,
-        matchId: matchId,
-        gameCreation: gameCreation,
-      },
-      { upsert: true },
-    );
+    await this.playModel.create({
+      puuid: puuid,
+      matchId: matchId,
+      gameCreation: gameCreation,
+    });
   }
 }

--- a/server/src/play/schemas/play.schema.ts
+++ b/server/src/play/schemas/play.schema.ts
@@ -18,4 +18,7 @@ export class Play extends Document {
   gameCreation: number;
 }
 
-export const PlaySchema = SchemaFactory.createForClass(Play);
+export const PlaySchema = SchemaFactory.createForClass(Play).index(
+  { puuid: 1, matchId: 1, gameCreation: 1 },
+  { unique: true },
+);

--- a/server/src/play/schemas/play.schema.ts
+++ b/server/src/play/schemas/play.schema.ts
@@ -19,6 +19,6 @@ export class Play extends Document {
 }
 
 export const PlaySchema = SchemaFactory.createForClass(Play).index(
-  { puuid: 1, matchId: 1, gameCreation: 1 },
+  { gameCreation: -1, matchId: -1, puuid: 1 },
   { unique: true },
 );


### PR DESCRIPTION
## 개요
- #258

## 작업사항
- contribution 계산시 total 값(divisor)가 0인 경우 NaN이 되어서 match가 저장이 안된다: 계산하기 전 0인지 확인
- ~~match 저장에 실패하고 play만 저장될 경우 재시도시 play가 여러개 생성된다: upsert 사용~~
  (index를 설정하면 중복이 생기지 않는다)
- version에 따라 challenges의 내용이 바뀐다: required 옵션 삭제
