### PR TITLE
fix: GameSlotDetail 레드팀 border-radius 설정

### DIFF
--- a/client/components/GameSlot/style.ts
+++ b/client/components/GameSlot/style.ts
@@ -139,6 +139,7 @@ export const detailStyle = {
     border-collapse: collapse;
     text-align: center;
     table-layout: fixed;
+    border-radius: 0 0 ${teamId === 200 ? '10px 10px' : '0 0'};
     thead {
       background-color: ${theme.neutral};
       font-size: 12px;


### PR DESCRIPTION
## 개요
- #262

## 작업사항
- GameSlot Detail의 레드팀(아래 팀) `border-radius: 0 0 10px 10px;`로 설정