### PR TITLE
fix: 소환사 이름이 다른 소환사 이름에 포함되는 문제 해결

### DIFF
--- a/server/src/summoners/summoners.service.ts
+++ b/server/src/summoners/summoners.service.ts
@@ -13,7 +13,7 @@ export class SummonersService {
 
   async findOne(summonerName: string) {
     const summoner = await this.summonerModel
-      .findOne({ name: { $regex: new RegExp(summonerName, 'i') } })
+      .findOne({ name: { $regex: new RegExp('^' + summonerName + '$', 'i') } })
       .lean();
 
     if (!summoner) throw new NotFoundException('해당 소환사가 없습니다.');


### PR DESCRIPTION
## 개요
- #271 

## 작업사항
- 정규표현식을 다음과 같이 수정하여 문제 해결

수정 전
```ts
new RegExp(summonerName, 'i')
```

수정 후
```ts
new RegExp('^' + summonerName + '$', 'i')
```