### PR TITLE
fix: 소환사가 없을 때 다시 검색이 되지 않는 문제 해결

### DIFF
--- a/client/pages/summoners/[summonerName].tsx
+++ b/client/pages/summoners/[summonerName].tsx
@@ -83,6 +83,8 @@ export default function SearchPage() {
 
   const handleSearch = () => {
     if (searchText === '') return;
+    setSummonerNotFound(false);
+    setSummonerName('');
     router.push(`/summoners/${searchText}`);
   };
 
@@ -93,6 +95,7 @@ export default function SearchPage() {
       setSearchText(query.summonerName);
     }
   }, [router.isReady, router.query]);
+
   return (
     <>
       <header css={style.header}>


### PR DESCRIPTION
## 개요
- #268

## 작업사항
- 다시 검색할 때 `summonerName`, `summonerNotFound`를 초기화하도록 수정
