### PR TITLE
소환사 정보가 갱신되지 않는 문제 수정

### DIFF
--- a/server/src/matches/matches.module.ts
+++ b/server/src/matches/matches.module.ts
@@ -6,6 +6,7 @@ import { Summoner, SummonerSchema } from '../summoners/schemas/summoner.schema';
 import { MatchesController } from './matches.controller';
 import { MatchesService } from './matches.service';
 import { Match, matchSchema } from './schemas/match.schema';
+import { SummonersModule } from 'src/summoners/summoners.module';
 
 @Module({
   imports: [
@@ -13,6 +14,7 @@ import { Match, matchSchema } from './schemas/match.schema';
     MongooseModule.forFeature([{ name: Summoner.name, schema: SummonerSchema }]),
     RiotApiModule,
     PlayModule,
+    SummonersModule,
   ],
   controllers: [MatchesController],
   providers: [MatchesService],

--- a/server/src/matches/matches.module.ts
+++ b/server/src/matches/matches.module.ts
@@ -6,7 +6,7 @@ import { Summoner, SummonerSchema } from '../summoners/schemas/summoner.schema';
 import { MatchesController } from './matches.controller';
 import { MatchesService } from './matches.service';
 import { Match, matchSchema } from './schemas/match.schema';
-import { SummonersModule } from 'src/summoners/summoners.module';
+import { SummonersModule } from '../summoners/summoners.module';
 
 @Module({
   imports: [

--- a/server/src/matches/matches.service.ts
+++ b/server/src/matches/matches.service.ts
@@ -6,7 +6,7 @@ import { RiotApiException } from '../riot.api/definition/riot.api.exception';
 import { RiotApiService } from '../riot.api/riot.api.service';
 import { Summoner, SummonerDocument } from '../summoners/schemas/summoner.schema';
 import { Contribution, Match, MatchDocument, TeamContribution } from './schemas/match.schema';
-import { SummonersService } from 'src/summoners/summoners.service';
+import { SummonersService } from '../summoners/summoners.service';
 
 @Injectable()
 export class MatchesService {

--- a/server/src/matches/matches.service.ts
+++ b/server/src/matches/matches.service.ts
@@ -6,6 +6,7 @@ import { RiotApiException } from '../riot.api/definition/riot.api.exception';
 import { RiotApiService } from '../riot.api/riot.api.service';
 import { Summoner, SummonerDocument } from '../summoners/schemas/summoner.schema';
 import { Contribution, Match, MatchDocument, TeamContribution } from './schemas/match.schema';
+import { SummonersService } from 'src/summoners/summoners.service';
 
 @Injectable()
 export class MatchesService {
@@ -17,6 +18,7 @@ export class MatchesService {
     @InjectModel(Summoner.name) private summonerModel: Model<SummonerDocument>,
     private readonly riotApiService: RiotApiService,
     private readonly playService: PlayService,
+    private readonly summonerService: SummonersService,
   ) {}
 
   async findOne(matchId: number) {
@@ -171,9 +173,7 @@ export class MatchesService {
         else if (r.status === 'rejected') this.logger.error(r.reason);
       });
 
-      await this.summonerModel
-        .updateOne({ puuid: puuid }, { updatedAt: new Date() }, { timestamps: false })
-        .lean();
+      this.summonerService.update(summoner.name);
     })();
 
     return {

--- a/server/src/matches/test/matches.service.spec.ts
+++ b/server/src/matches/test/matches.service.spec.ts
@@ -15,6 +15,7 @@ import {
 } from './matches.mock';
 import { RiotApiException } from '../../riot.api/definition/riot.api.exception';
 import { mockSummoner } from '../../summoners/test/summoners.mock';
+import { SummonersService } from '../../summoners/summoners.service';
 
 describe('MatchesService', () => {
   const puuid = 'wQ9X1e4FSY47C_MoncM1F6gsc7SkU2fGuw0WpP4dLnj7sbeakbg_x2lUDRbP5bGQEEB_1b7z67_B-Q';
@@ -55,6 +56,12 @@ describe('MatchesService', () => {
           useValue: {
             create: jest.fn(),
             findMany: jest.fn(),
+          },
+        },
+        {
+          provide: SummonersService,
+          useValue: {
+            update: jest.fn(),
           },
         },
       ],

--- a/server/src/summoners/summoners.module.ts
+++ b/server/src/summoners/summoners.module.ts
@@ -12,5 +12,6 @@ import { SummonersService } from './summoners.service';
   ],
   controllers: [SummonersController],
   providers: [SummonersService],
+  exports: [SummonersService],
 })
 export class SummonersModule {}


### PR DESCRIPTION
## 개요
- #311

## 작업사항
- `matches.service`에서 모든 갱신 작업 이후 소환사의 `updatedAt` 수정하는 부분을 `summonerService.update()`로 수정해서 갱신하도록 함
